### PR TITLE
Bump buildroot to 2026.02.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # --- Buildroot versioning ----------------------------------------------------
-BUILDROOT_VERSION ?= 2026.02
+BUILDROOT_VERSION ?= 2026.02.1
 BUILDROOT_URL ?= https://buildroot.org/downloads/buildroot-$(BUILDROOT_VERSION).tar.gz
 
 ROOT_DIR := $(CURDIR)


### PR DESCRIPTION
This pull request updates the Buildroot version used in the `Makefile` to ensure the project uses the latest available release.

Version update:

* Changed the default `BUILDROOT_VERSION` from `2026.02` to `2026.02.1` in the `Makefile` to use the latest Buildroot release.